### PR TITLE
Fix to release ctx->header if it is not consumed by render

### DIFF
--- a/include/rpigrafx.h
+++ b/include/rpigrafx.h
@@ -18,6 +18,7 @@
         MMAL_STATUS_T status;
         MMAL_BUFFER_HEADER_T *header;
         VCOS_SEMAPHORE_T sem;
+        _Bool is_header_passed_to_render;
     };
 
     typedef struct {


### PR DESCRIPTION
Fix to release `ctx->header` on `rpigrafx_capture_next_frame()` if it's not consumed by `vc.ril.render` i.e. if the header is not yet released.

The previous code prevented users to get frames without rendering them. Now that's fixed.