### PR TITLE
Add an option to use the camera capture port

### DIFF
--- a/include/rpigrafx.h
+++ b/include/rpigrafx.h
@@ -27,6 +27,11 @@
         struct callback_context *ctx;
     } rpigrafx_frame_config_t;
 
+    typedef enum {
+        RPIGRAFX_CAMERA_PORT_PREVIEW,
+        RPIGRAFX_CAMERA_PORT_CAPTURE
+    } rpigrafx_camera_port_t;
+
     int rpigrafx_init()     __attribute__((constructor));
     int rpigrafx_finalize() __attribute__((destructor));
 
@@ -35,6 +40,8 @@
                                      const MMAL_FOURCC_T encoding,
                                      const _Bool is_zero_copy_rendering,
                                      rpigrafx_frame_config_t *fcp);
+    int rpigrafx_config_camera_port(const int32_t camera_number,
+                                    const rpigrafx_camera_port_t camera_port);
     int rpigrafx_config_camera_frame_render(const _Bool is_fullscreen,
                                             const int32_t x, const int32_t y,
                                             const int32_t width, const int32_t height,

--- a/src/mmal.c
+++ b/src/mmal.c
@@ -386,7 +386,7 @@ static int setup_cp_camera(const int i,
             goto end;
         }
 
-        status = config_port(output, MMAL_ENCODING_RGBA, width, height);
+        status = config_port(output, MMAL_ENCODING_OPAQUE, width, height);
         if (status != MMAL_SUCCESS) {
             print_error("Setting format of camera %d failed: 0x%08x", i, status);
             ret = 1;
@@ -481,7 +481,7 @@ static int setup_cp_null(const int i,
             goto end;
         }
 
-        status = config_port(input, MMAL_ENCODING_RGBA, width, height);
+        status = config_port(input, MMAL_ENCODING_OPAQUE, width, height);
         if (status != MMAL_SUCCESS) {
             print_error("Setting format of null %d failed: 0x%08x", i, status);
             ret = 1;

--- a/src/mmal.c
+++ b/src/mmal.c
@@ -855,6 +855,15 @@ static int connect_ports(const int i, const int len)
             goto end;
         }
     }
+    if (cfg->use_camera_capture_port) {
+        status = mmal_connection_enable(conn_camera_nulls[i]);
+        if (status != MMAL_SUCCESS) {
+            print_error("Enabling connection between " \
+                        "camera and null %d,%d failed: 0x%08x", i, j, status);
+            ret = 1;
+            goto end;
+        }
+    }
     status = mmal_connection_enable(conn_camera_splitters[i]);
     if (status != MMAL_SUCCESS) {
         print_error("Enabling connection between " \

--- a/src/mmal.c
+++ b/src/mmal.c
@@ -446,7 +446,7 @@ static int setup_cp_null(const int i,
     MMAL_STATUS_T status;
     int ret = 0;
 
-    status = mmal_component_create("vc.ril.null_sink", &cp_nulls[i]);
+    status = mmal_component_create("vc.null_sink", &cp_nulls[i]);
     if (status != MMAL_SUCCESS) {
         print_error("Creating null component of camera %d failed: 0x%08x",
                     i, status);


### PR DESCRIPTION
Add an option to use the camera capture port, which some users wanted to use for zero-latency capture.

Note that the capture port is so slow (about ~2 frame/s). I will investigate why.