### PR TITLE
use AC_CHECK_LIB if .pc file is not found

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,12 +22,49 @@ AC_PROG_CC
 AM_PROG_AR
 
 # Checks for libraries.
-PKG_CHECK_MODULES([BCM_HOST], [bcm_host], , [AC_MSG_ERROR("missing -lbcm_host")])
-AC_SUBST([BCM_HOST_CFLAGS])
-AC_SUBST([BCM_HOST_LIBS])
-PKG_CHECK_MODULES([MMAL], [mmal], , [AC_MSG_ERROR("missing -lmmal")])
-AC_SUBST([MMAL_CFLAGS])
-AC_SUBST([MMAL_LIBS])
+PKG_CHECK_MODULES([BCM_HOST], [bcm_host],
+                  [AC_SUBST([BCM_HOST_CFLAGS])
+                   AC_SUBST([BCM_HOST_LIBS])],
+                  [librpigrafx_cv_have_bcm_host="no"])
+if test "$librpigrafx_cv_have_bcm_host" = "no"; then
+  AC_CHECK_LIB([vcos], [vcos_vsnprintf],
+               [],
+               [AC_MSG_ERROR("missing -lvcos")])
+  AC_CHECK_LIB([vchiq_arm], [vchiu_queue_init],
+               [],
+               [AC_MSG_ERROR("missing -lvchiq_arm")])
+  AC_CHECK_LIB([bcm_host], [bcm_host_init],
+               [],
+               [AC_MSG_ERROR("missing -lbcm_host")])
+fi
+PKG_CHECK_MODULES([MMAL], [mmal],
+                  [AC_SUBST([MMAL_CFLAGS])
+                   AC_SUBST([MMAL_LIBS])],
+                  [librpigrafx_cv_have_mmal="no"])
+if test "$librpigrafx_cv_have_mmal" = "no"; then
+  AC_CHECK_LIB([vcsm], [vcsm_init],
+               [],
+               [AC_MSG_ERROR("missing -lvcsm")])
+  AC_CHECK_LIB([mmal_util], [mmal_util_rgb_order_fixed],
+               [],
+               [AC_MSG_ERROR("missing -lmmal_util")],
+               [-lmmal_core])
+  AC_CHECK_LIB([mmal_core], [mmal_ports_alloc],
+               [],
+               [AC_MSG_ERROR("missing -lmmal_core")])
+  AC_CHECK_LIB([containers], [vc_uri_path],
+               [],
+               [AC_MSG_ERROR("missing -lcontainers")])
+  AC_CHECK_LIB([mmal_components], [mmal_register_component_null_sink],
+               [],
+               [AC_MSG_ERROR("missing -lmmal_components")])
+  AC_CHECK_LIB([mmal], [mmal_status_to_string],
+               [],
+               [AC_MSG_ERROR("missing -lmmal")])
+  AC_CHECK_LIB([mmal_vc_client], [mmal_vc_use],
+               [],
+               [AC_MSG_ERROR("missing -lmmal_vc_client")])
+fi
 AC_CHECK_LIB([qmkl], [mailbox_qpu_enable],
              [QMKL_LIBS=-lqmkl
               AC_SUBST(QMKL_LIBS)],
@@ -35,6 +72,7 @@ AC_CHECK_LIB([qmkl], [mailbox_qpu_enable],
 
 # Checks for header files.
 AC_CHECK_HEADERS([stdio.h stdint.h stdlib.h])
+AC_CHECK_HEADER([bcm_host.h], [], [AC_MSG_ERROR("missing bcm_host.h")])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_TYPE_UINT32_T


### PR DESCRIPTION
If build host have no .pc file for raspi firmware lib (ex. cross-compiling), configure like this.

~~~~sh
$ mkdir build
$ cd ~/build
$ dpkg -X libraspberrypi0.deb .
$ dpkg -X libraspberrypi-dev.deb .
(Install qmkl to $HOME/cross/usr/armv6-rpi-linux-gnueabihf/)
$ cd ~/librpigrafx2
$ ./configure \
  --build=x86_64-pc-linux-gnu \
  --host=armv6-rpi-linux-gnueabihf \
  LDFLAGS="-L$HOME/build/opt/vc/lib -L$HOME/cross/usr/armv6-rpi-linux-gnueabihf/lib" \
  CPPFLAGS="-I$HOME/build/opt/vc/include -I$HOME/cross/usr/armv6-rpi-linux-gnueabihf/include"
~~~~
