### PR TITLE
mmal: Support for rawcam

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ config.status
 
 /test/test_dispmanx
 /test/test_capture_render_seq
+/test/test_rawcam_imx219
 
 
 # Created by https://www.gitignore.io/api/c,vim,git,macos,linux,emacs,windows,autotools

--- a/README.md
+++ b/README.md
@@ -16,5 +16,40 @@
 $ autoreconf -i -m
 $ PKG_CONFIG_PATH=/opt/vc/lib/pkgconfig ./configure
 $ make
+$ make check
 $ sudo make install
+```
+
+
+# How to run
+
+```
+$ sudo ./test/test_capture_render_seq
+```
+
+`sudo` is needed here because it uses
+[qmkl](https://github.com/Terminus-IMRC/qmkl), which uses `/dev/mem` to
+communicate with GPU, for testing of resource confliction.
+
+
+## Using rawcam
+
+The official IMX219 camera module is protected by a cryptographic chip
+[ATSHA204A](http://www.microchip.com/wwwproducts/en/ATSHA204A) not to let users
+to use their ISP (image signal processor) and algorithms *fully* for processing
+raw image from camera.
+
+This library supports rawcam, which is a framework provided by the Raspberry Pi
+firmware. rawcam enables to receive raw image from MIPI/CSI-2 image sensor
+directly. With it, **you can use non-official cameras i.e. without cryptographic
+chips**. In addition, this library implements raw image processing, AWB, etc. so
+you can use it without much configurations.
+
+Currently, our rawcam support is limited to IMX219. How to run:
+
+```
+$ wget https://raw.githubusercontent.com/6by9/userland/rawcam/camera_i2c
+$ chmod u+x camera_i2c
+$ ./camera_i2c
+$ ./test/test_rawcam_imx219
 ```

--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,9 @@ AC_SUBST([pkgconfigdir])
 AC_PROG_CC
 AM_PROG_AR
 
+
 # Checks for libraries.
+
 PKG_CHECK_MODULES([BCM_HOST], [bcm_host],
                   [AC_SUBST([BCM_HOST_CFLAGS])
                    AC_SUBST([BCM_HOST_LIBS])],
@@ -37,6 +39,7 @@ if test "$librpigrafx_cv_have_bcm_host" = "no"; then
                [],
                [AC_MSG_ERROR("missing -lbcm_host")])
 fi
+
 PKG_CHECK_MODULES([MMAL], [mmal],
                   [AC_SUBST([MMAL_CFLAGS])
                    AC_SUBST([MMAL_LIBS])],
@@ -65,18 +68,30 @@ if test "$librpigrafx_cv_have_mmal" = "no"; then
                [],
                [AC_MSG_ERROR("missing -lmmal_vc_client")])
 fi
+
 AC_CHECK_LIB([qmkl], [mailbox_qpu_enable],
              [QMKL_LIBS=-lqmkl
               AC_SUBST(QMKL_LIBS)],
              [AC_MSG_ERROR("missing -lqmkl")])
+
 PKG_CHECK_MODULES([RPICAM], [librpicam],
-                 [AC_SUBST([RPICAM_CFLAGS])
+                  [_have_rpicam=yes
+                  AC_SUBST([RPICAM_CFLAGS])
                   AC_SUBST([RPICAM_LIBS])],
-                 [AC_MSG_ERROR("missing -lrpicam")])
+                  [have_rpicam=no])
+AS_IF([test x${_have_rpicam} = "xyes"],
+      [AC_DEFINE([HAVE_RPICAM], 1, [Define to 1 if you have librpicam.])])
+AM_CONDITIONAL([HAVE_RPICAM], [test "x${_have_rpicam}" = "xyes"])
+
 PKG_CHECK_MODULES([RPIRAW], [librpiraw],
-                  [AC_SUBST([RPIRAW_CFLAGS])
+                  [_have_rpiraw=yes
+                  AC_SUBST([RPIRAW_CFLAGS])
                   AC_SUBST([RPIRAW_LIBS])],
-                 [AC_MSG_ERROR("missing -lrpiraw")])
+                  [have_rpiraw=no])
+AS_IF([test x${_have_rpiraw} = "xyes"],
+      [AC_DEFINE([HAVE_RPIRAW], 1, [Define to 1 if you have librpiraw.])])
+AM_CONDITIONAL([HAVE_RPIRAW], [test "x${_have_rpiraw}" = "xyes"])
+
 
 # Checks for header files.
 AC_CHECK_HEADERS([stdio.h stdint.h stdlib.h])

--- a/configure.ac
+++ b/configure.ac
@@ -69,6 +69,14 @@ AC_CHECK_LIB([qmkl], [mailbox_qpu_enable],
              [QMKL_LIBS=-lqmkl
               AC_SUBST(QMKL_LIBS)],
              [AC_MSG_ERROR("missing -lqmkl")])
+PKG_CHECK_MODULES([RPICAM], [librpicam],
+                 [AC_SUBST([RPICAM_CFLAGS])
+                  AC_SUBST([RPICAM_LIBS])],
+                 [AC_MSG_ERROR("missing -lrpicam")])
+PKG_CHECK_MODULES([RPIRAW], [librpiraw],
+                  [AC_SUBST([RPIRAW_CFLAGS])
+                  AC_SUBST([RPIRAW_LIBS])],
+                 [AC_MSG_ERROR("missing -lrpiraw")])
 
 # Checks for header files.
 AC_CHECK_HEADERS([stdio.h stdint.h stdlib.h])

--- a/include/rpigrafx.h
+++ b/include/rpigrafx.h
@@ -37,6 +37,13 @@
     } rpigrafx_rawcam_camera_model_t;
 
     typedef enum {
+        RPIGRAFX_BAYER_PATTERN_BGGR,
+        RPIGRAFX_BAYER_PATTERN_GRBG,
+        RPIGRAFX_BAYER_PATTERN_GBRG,
+        RPIGRAFX_BAYER_PATTERN_RGGB
+    } rpigrafx_bayer_pattern_t;
+
+    typedef enum {
         RPIGRAFX_RAWCAM_IMX219_BINNING_MODE_NONE
     } rpigrafx_rawcam_imx219_binning_mode_t;
 
@@ -56,6 +63,7 @@
                                const MMAL_CAMERA_RX_CONFIG_PACK   pack,
                                const uint32_t data_lanes,
                                const uint32_t nbits_of_raw_from_camera,
+                               const rpigrafx_bayer_pattern_t bayer_pattern,
                                rpigrafx_frame_config_t *fcp);
     int rpigrafx_config_rawcam_imx219(const float exck_freq,
                                       uint_least16_t x, uint_least16_t y,

--- a/include/rpigrafx.h
+++ b/include/rpigrafx.h
@@ -32,6 +32,14 @@
         RPIGRAFX_CAMERA_PORT_CAPTURE
     } rpigrafx_camera_port_t;
 
+    typedef enum {
+        RPIGRAFX_RAWCAM_CAMERA_MODEL_IMX219
+    } rpigrafx_rawcam_camera_model_t;
+
+    typedef enum {
+        RPIGRAFX_RAWCAM_IMX219_BINNING_MODE_NONE
+    } rpigrafx_rawcam_imx219_binning_mode_t;
+
     int rpigrafx_init()     __attribute__((constructor));
     int rpigrafx_finalize() __attribute__((destructor));
 
@@ -40,6 +48,21 @@
                                      const MMAL_FOURCC_T encoding,
                                      const _Bool is_zero_copy_rendering,
                                      rpigrafx_frame_config_t *fcp);
+    int rpigrafx_config_rawcam(const rpigrafx_rawcam_camera_model_t
+                                                                   camera_model,
+                               const MMAL_CAMERA_RX_CONFIG_DECODE decode,
+                               const MMAL_CAMERA_RX_CONFIG_ENCODE encode,
+                               const MMAL_CAMERA_RX_CONFIG_UNPACK unpack,
+                               const MMAL_CAMERA_RX_CONFIG_PACK   pack,
+                               const uint32_t data_lanes,
+                               const uint32_t nbits_of_raw_from_camera,
+                               rpigrafx_frame_config_t *fcp);
+    int rpigrafx_config_rawcam_imx219(const float exck_freq,
+                                      uint_least16_t x, uint_least16_t y,
+                                      _Bool orient_hori, _Bool orient_vert,
+                                      rpigrafx_rawcam_imx219_binning_mode_t
+                                                                   binning_mode,
+                                      rpigrafx_frame_config_t *fcp);
     int rpigrafx_config_camera_port(const int32_t camera_number,
                                     const rpigrafx_camera_port_t camera_port);
     int rpigrafx_config_camera_frame_render(const _Bool is_fullscreen,

--- a/librpigrafx.pc.in
+++ b/librpigrafx.pc.in
@@ -6,6 +6,6 @@ includedir=@includedir@
 Name: @PACKAGE@
 Description: Graphic library for Raspberry Pi
 Version: @VERSION@
-Requires: bcm_host mmal
+Requires: bcm_host mmal rpicam rpiraw
 Cflags: -I${includedir}
 Libs: -L${libdir} -lrpigrafx

--- a/src/mmal.c
+++ b/src/mmal.c
@@ -11,7 +11,10 @@
 #include <interface/mmal/util/mmal_util.h>
 #include <interface/mmal/util/mmal_util_params.h>
 #include <interface/mmal/util/mmal_connection.h>
+#include <interface/mmal/util/mmal_component_wrapper.h>
 #include <interface/mmal/util/mmal_default_components.h>
+#include <rpicam.h>
+#include <rpiraw.h>
 #include "rpigrafx.h"
 #include "local.h"
 
@@ -24,30 +27,56 @@ static int32_t num_cameras = 0;
 
 /*
  * When camera->output[0] is used as a capture port:
- * camera [0] --- [0] video_splitter [0] --- [0] isp [0] --- [0] video_render
- *                                   [1] --- [0] isp [0] --- [0] video_render
- *                                   [2] --- [0] isp [0] --- [0] video_render
- *                                   [3] --- [0] isp [0] --- [0] video_render
+ * camera [0] --- [0] splitter [0] --- [0] isp [0] --- [0] render
+ *                             [1] --- [0] isp [0] --- [0] render
+ *                             [2] --- [0] isp [0] --- [0] render
+ *                             [3] --- [0] isp [0] --- [0] render
  *
  * When vc.ril.camera->output[2] is used as a capture port,
  * the preview port (camera->output[0]) is still used for AWB processing:
  * camera [0] --- [0] null_sink
- *        [2] --- [0] video_splitter [0] --- [0] isp [0] --- [0] video_render
- *                                   [1] --- [0] isp [0] --- [0] video_render
- *                                   [2] --- [0] isp [0] --- [0] video_render
- *                                   [3] --- [0] isp [0] --- [0] video_render
+ *        [2] --- [0] splitter [0] --- [0] isp [0] --- [0] render
+ *                             [1] --- [0] isp [0] --- [0] render
+ *                             [2] --- [0] isp [0] --- [0] render
+ *                             [3] --- [0] isp [0] --- [0] render
+ *
+ * When vc.ril.rawcam->output[0] is used as a capture port,
+ * camera control via I2C and hardware-side AWB processing are done by librpicam
+ * and demosaicing and software-side AWB processing is done by librpiraw.
+ * rawcam [0] --- (demosaic) --- [0] splitter [0] --- [0] isp [0] --- [0] render
+ *                                            [1] --- [0] isp [0] --- [0] render
+ *                                            [2] --- [0] isp [0] --- [0] render
+ *                                            [3] --- [0] isp [0] --- [0] render
+ */
+
+/*
+ * Because raw image from camera won't be directly passed to render, we need to
+ * allocate port pools for rawcam->output[0] and splitter->input[0] manually,
+ * which was done by mmal_connection_create() or in the firmware. Allocating the
+ * pools can be achieved by calling the raw MMAL funcs, but it's easier to use
+ * the wrapper.
  */
 
 static MMAL_COMPONENT_T *cp_cameras[MAX_CAMERAS];
+static MMAL_WRAPPER_T *cpw_rawcams[MAX_CAMERAS];
 static struct cameras_config {
     _Bool is_used;
     int32_t width, height;
     int32_t max_width, max_height;
     unsigned camera_output_port_index;
     _Bool use_camera_capture_port;
+
+    _Bool is_rawcam;
+    rpigrafx_rawcam_camera_model_t rawcam_camera_model;
+    unsigned nbits_of_raw_from_camera;
+    MMAL_PARAMETER_CAMERA_RX_CONFIG_T rx_cfg;
+    union {
+        struct rpicam_imx219_config imx219;
+    } rpicam_config;
 } cameras_config[MAX_CAMERAS];
 
 static MMAL_COMPONENT_T *cp_splitters[MAX_CAMERAS];
+static MMAL_WRAPPER_T *cpw_splitters[MAX_CAMERAS];
 static struct splitters_config {
     int next_output_idx;
 } splitters_config[MAX_CAMERAS];
@@ -290,6 +319,117 @@ end:
     return ret;
 }
 
+int rpigrafx_config_rawcam(const rpigrafx_rawcam_camera_model_t camera_model,
+                           const MMAL_CAMERA_RX_CONFIG_DECODE decode,
+                           const MMAL_CAMERA_RX_CONFIG_ENCODE encode,
+                           const MMAL_CAMERA_RX_CONFIG_UNPACK unpack,
+                           const MMAL_CAMERA_RX_CONFIG_PACK   pack,
+                           const uint32_t data_lanes,
+                           const uint32_t nbits_of_raw_from_camera,
+                           rpigrafx_frame_config_t *fcp)
+{
+    uint32_t image_id;
+    MMAL_PARAMETER_CAMERA_RX_CONFIG_T rx_cfg;
+    int ret = 0;
+
+    /*
+     * See the MIPI specification for the values. If your one's version is
+     * 1.01.00 r0.04 2-Apr-2009, they're on p.88.
+     */
+    switch (nbits_of_raw_from_camera) {
+        case 6:
+            image_id = 0x28;
+            break;
+        case 7:
+            image_id = 0x29;
+            break;
+        case 8:
+            image_id = 0x2a;
+            break;
+        case 10:
+            image_id = 0x2b;
+            break;
+        case 12:
+            image_id = 0x2c;
+            break;
+        case 14:
+            image_id = 0x2d;
+            break;
+        default:
+            print_error("Unsupported number of bits of raw from camera: %u",
+                        nbits_of_raw_from_camera);
+            ret = 1;
+            goto end;
+    }
+
+    rx_cfg.decode     = decode;
+    rx_cfg.encode     = encode;
+    rx_cfg.unpack     = unpack;
+    rx_cfg.pack       = pack;
+    rx_cfg.data_lanes = data_lanes;
+    rx_cfg.image_id   = image_id;
+    memcpy(&cameras_config[fcp->camera_number].rx_cfg, &rx_cfg, sizeof(rx_cfg));
+    cameras_config[fcp->camera_number].nbits_of_raw_from_camera =
+                                                       nbits_of_raw_from_camera;
+
+    cameras_config[fcp->camera_number].rawcam_camera_model = camera_model;
+    cameras_config[fcp->camera_number].is_rawcam = !0;
+
+end:
+    return ret;
+}
+
+int rpigrafx_config_rawcam_imx219(const float exck_freq,
+                                  uint_least16_t x, uint_least16_t y,
+                                  _Bool orient_hori, _Bool orient_vert,
+                                  rpigrafx_rawcam_imx219_binning_mode_t
+                                                                   binning_mode,
+                                  rpigrafx_frame_config_t *fcp)
+{
+    struct rpicam_imx219_config cfg;
+    int ret = 0;
+
+    if (cameras_config[fcp->camera_number].rawcam_camera_model !=
+                                          RPIGRAFX_RAWCAM_CAMERA_MODEL_IMX219) {
+        print_error("rawcam is not configured for IMX219");
+        ret = 1;
+        goto end;
+    }
+
+    rpicam_imx219_default_config(&cfg);
+    cfg.exck_freq.num = exck_freq * 1000;
+    cfg.exck_freq.den = 1000;
+    cfg.temperature_en = !0;
+    cfg.num_csi_lanes = cameras_config[fcp->camera_number].rx_cfg.data_lanes;
+    cfg.x = x;
+    cfg.y = y;
+    cfg.hori_orientation = orient_hori;
+    cfg.vert_orientation = orient_vert;
+    switch (cameras_config[fcp->camera_number].nbits_of_raw_from_camera) {
+        case 8:
+            cfg.comp_enable = !0;
+            break;
+        case 10:
+            cfg.comp_enable = 0;
+            break;
+        default:
+            print_error("IMX219 supports only for raw8 and raw10");
+            ret = 1;
+            goto end;
+    }
+    switch (binning_mode) {
+        case RPIGRAFX_RAWCAM_IMX219_BINNING_MODE_NONE:
+            /* Keep the defaults. */
+            break;
+    }
+
+    memcpy(&cameras_config[fcp->camera_number].rpicam_config.imx219, &cfg,
+           sizeof(cfg));
+
+end:
+    return ret;
+}
+
 int rpigrafx_config_camera_port(const int32_t camera_number,
                                 const rpigrafx_camera_port_t camera_port)
 {
@@ -336,8 +476,120 @@ int rpigrafx_config_camera_frame_render(const _Bool is_fullscreen,
     };
     int ret = 0;
 
-    memcpy(&renders_config[fcp->camera_number][fcp->splitter_output_port_index].region, &region, sizeof(region));
+    memcpy(&renders_config[fcp->camera_number]
+                                       [fcp->splitter_output_port_index].region,
+           &region, sizeof(region));
 
+    return ret;
+}
+
+static int setup_cp_camera_rawcam(const int i,
+                                  const int32_t width, const int32_t height)
+{
+    MMAL_STATUS_T status;
+    int ret = 0;
+
+    switch (cameras_config[i].rawcam_camera_model) {
+        case RPIGRAFX_RAWCAM_CAMERA_MODEL_IMX219: {
+            struct rpicam_imx219_config *stp = &cameras_config[i]
+                                                          .rpicam_config.imx219;
+            if ((ret = rpicam_imx219_open(stp)))
+                goto end;
+            break;
+        }
+    }
+
+    status = mmal_wrapper_create(&cpw_rawcams[i], "vc.ril.rawcam");
+    if (status != MMAL_SUCCESS) {
+        print_error("Creating rawcam component of camera %d failed: 0x%08x",
+                    i, status);
+        ret = 1;
+        goto end;
+    }
+
+    {
+        MMAL_PORT_T *control = mmal_util_get_port(cpw_rawcams[i]->component,
+                                                  MMAL_PORT_TYPE_CONTROL, 0);
+
+        if (control == NULL) {
+            print_error("Getting control port of camera %d failed", i);
+            ret = 1;
+            goto end;
+        }
+
+        //status = mmal_port_parameter_set_int32(control,
+                                               //MMAL_PARAMETER_CAMERA_NUM, i);
+        if (status != MMAL_SUCCESS) {
+            print_error("Setting camera_num of camera %d failed: 0x%08x",
+                        i, status);
+            ret = 1;
+            goto end;
+        }
+    }
+
+    {
+        MMAL_PORT_T *output = mmal_util_get_port(cpw_rawcams[i]->component,
+                                                 MMAL_PORT_TYPE_OUTPUT, 0);
+        MMAL_PARAMETER_CAMERA_RX_CONFIG_T rx_cfg = {
+            .hdr = {
+                .id = MMAL_PARAMETER_CAMERA_RX_CONFIG,
+                .size = sizeof(rx_cfg)
+            }
+        };
+
+        if (output == NULL) {
+            print_error("Getting output %d of camera %d failed", 0, i);
+            ret = 1;
+            goto end;
+        }
+
+        /* xxx: Change the encoding according to nbits_of_raw_from_camera. */
+        status = config_port(output, MMAL_ENCODING_BAYER_SBGGR10P, width, height);
+        if (status != MMAL_SUCCESS) {
+            print_error("Setting format of camera %d failed: 0x%08x",
+                        i, status);
+            ret = 1;
+            goto end;
+        }
+
+        status = mmal_port_parameter_get(output, &rx_cfg.hdr);
+        if (status != MMAL_SUCCESS) {
+            print_error("Getting rx_cfg of rawcam %d failed: 0x%08x",
+                        i, status);
+            ret = 1;
+            goto end;
+        }
+
+        /* Use default values for encode_block_length and embedded_data_lines. */
+        rx_cfg.decode     = cameras_config[i].rx_cfg.decode;
+        rx_cfg.encode     = cameras_config[i].rx_cfg.encode;
+        rx_cfg.unpack     = cameras_config[i].rx_cfg.unpack;
+        rx_cfg.pack       = cameras_config[i].rx_cfg.pack;
+        rx_cfg.data_lanes = cameras_config[i].rx_cfg.data_lanes;
+        rx_cfg.image_id   = cameras_config[i].rx_cfg.image_id;
+        status = mmal_port_parameter_set(output, &rx_cfg.hdr);
+        if (status != MMAL_SUCCESS) {
+            print_error("Setting rx_cfg of rawcam %d failed: 0x%08x",
+                        i, status);
+            ret = 1;
+            goto end;
+        }
+
+        status = mmal_wrapper_port_enable(output,
+                                          MMAL_WRAPPER_FLAG_PAYLOAD_ALLOCATE);
+        if (status != MMAL_SUCCESS) {
+            print_error("Enabling rawcam component of camera %d failed: 0x%08x",
+                        i, status);
+            ret = 1;
+            goto end;
+        }
+
+        MMAL_BUFFER_HEADER_T *header = NULL;
+        while ((header = mmal_queue_get(cpw_rawcams[i]->output_pool[0]->queue)) != NULL)
+            mmal_port_send_buffer(output, header);
+    }
+
+end:
     return ret;
 }
 
@@ -517,21 +769,34 @@ end:
 }
 
 static int setup_cp_splitter(const int i, const int len,
-                             const int32_t width, const int32_t height)
+                             const int32_t width, const int32_t height,
+                             const _Bool is_rawcam)
 {
     int j;
+    MMAL_COMPONENT_T *component = NULL;
     MMAL_STATUS_T status;
     int ret = 0;
 
-    status = mmal_component_create(MMAL_COMPONENT_DEFAULT_VIDEO_SPLITTER, &cp_splitters[i]);
+    if (!is_rawcam)
+        status = mmal_component_create(MMAL_COMPONENT_DEFAULT_VIDEO_SPLITTER,
+                                       &cp_splitters[i]);
+    else
+        status = mmal_wrapper_create(&cpw_splitters[i],
+                                     MMAL_COMPONENT_DEFAULT_VIDEO_SPLITTER);
     if (status != MMAL_SUCCESS) {
         print_error("Creating splitter component of camera %d failed: 0x%08x",
                     i, status);
         ret = 1;
         goto end;
     }
+
+    if (!is_rawcam)
+        component = cp_splitters[i];
+    else
+        component = cpw_splitters[i]->component;
+
     {
-        MMAL_PORT_T *control = mmal_util_get_port(cp_splitters[i],
+        MMAL_PORT_T *control = mmal_util_get_port(component,
                                                   MMAL_PORT_TYPE_CONTROL, 0);
 
         if (control == NULL) {
@@ -540,16 +805,18 @@ static int setup_cp_splitter(const int i, const int len,
             goto end;
         }
 
-        status = mmal_port_enable(control, callback_control);
-        if (status != MMAL_SUCCESS) {
-            print_error("Enabling control port of splitter %d failed: 0x%08x",
-                        i, status);
-            ret = 1;
-            goto end;
+        if (!is_rawcam) {
+            status = mmal_port_enable(control, callback_control);
+            if (status != MMAL_SUCCESS) {
+                print_error("Enabling control port of splitter %d failed: 0x%08x",
+                            i, status);
+                ret = 1;
+                goto end;
+            }
         }
     }
     {
-        MMAL_PORT_T *input = mmal_util_get_port(cp_splitters[i],
+        MMAL_PORT_T *input = mmal_util_get_port(component,
                                                 MMAL_PORT_TYPE_INPUT, 0);
 
         if (input == NULL) {
@@ -566,6 +833,7 @@ static int setup_cp_splitter(const int i, const int len,
             goto end;
         }
 
+        if (!is_rawcam) {
         status = mmal_port_parameter_set_boolean(input,
                                             MMAL_PARAMETER_ZERO_COPY, MMAL_TRUE);
         if (status != MMAL_SUCCESS) {
@@ -574,9 +842,22 @@ static int setup_cp_splitter(const int i, const int len,
             ret = 1;
             goto end;
         }
+        }
+
+        if (is_rawcam) {
+            status = mmal_wrapper_port_enable(input,
+                                            MMAL_WRAPPER_FLAG_PAYLOAD_ALLOCATE);
+            if (status != MMAL_SUCCESS) {
+                print_error("Enabling input port 0 of "
+                            "splitter component %d failed: 0x%08x",
+                            i, status);
+                ret = 1;
+                goto end;
+            }
+        }
     }
     for (j = 0; j < len; j ++) {
-        MMAL_PORT_T *output = mmal_util_get_port(cp_splitters[i],
+        MMAL_PORT_T *output = mmal_util_get_port(component,
                                                  MMAL_PORT_TYPE_OUTPUT, j);
 
         if (output == NULL) {
@@ -602,12 +883,15 @@ static int setup_cp_splitter(const int i, const int len,
             goto end;
         }
     }
-    status = mmal_component_enable(cp_splitters[i]);
-    if (status != MMAL_SUCCESS) {
-        print_error("Enabling splitter component of " \
-                    "camera %d failed: 0x%08x", i, status);
-        ret = 1;
-        goto end;
+
+    if (!is_rawcam) {
+        status = mmal_component_enable(cp_splitters[i]);
+        if (status != MMAL_SUCCESS) {
+            print_error("Enabling splitter component of " \
+                        "camera %d failed: 0x%08x", i, status);
+            ret = 1;
+            goto end;
+        }
     }
 
 end:
@@ -693,7 +977,8 @@ static int setup_cp_isp(const int i, const int j,
         }
 
         status = mmal_port_parameter_set_boolean(output,
-                                            MMAL_PARAMETER_ZERO_COPY, MMAL_TRUE);
+                                                 MMAL_PARAMETER_ZERO_COPY,
+                                                 MMAL_TRUE);
         if (status != MMAL_SUCCESS) {
             print_error("Setting zero-copy on " \
                         "isp %d output %d failed: 0x%08x", i, j, status);
@@ -703,7 +988,8 @@ static int setup_cp_isp(const int i, const int j,
     }
     status = mmal_component_enable(cp_isps[i][j]);
     if (status != MMAL_SUCCESS) {
-        print_error("Enabling isp component %d,%d failed: 0x%08x", i, j, status);
+        print_error("Enabling isp component %d,%d failed: 0x%08x",
+                    i, j, status);
         ret = 1;
         goto end;
     }
@@ -717,9 +1003,11 @@ static int setup_cp_render(const int i, const int j)
     MMAL_STATUS_T status;
     int ret = 0;
 
-    status = mmal_component_create(MMAL_COMPONENT_DEFAULT_VIDEO_RENDERER, &cp_renders[i][j]);
+    status = mmal_component_create(MMAL_COMPONENT_DEFAULT_VIDEO_RENDERER,
+                                   &cp_renders[i][j]);
     if (status != MMAL_SUCCESS) {
-        print_error("Creating render component %d,%d failed: 0x%08x", i, j, status);
+        print_error("Creating render component %d,%d failed: 0x%08x",
+                    i, j, status);
         ret = 1;
         goto end;
     }
@@ -762,7 +1050,8 @@ static int setup_cp_render(const int i, const int j)
             goto end;
         }
 
-        status = mmal_util_set_display_region(input, &renders_config[i][j].region);
+        status = mmal_util_set_display_region(input,
+                                              &renders_config[i][j].region);
         if (status != MMAL_SUCCESS) {
             print_error("Setting region of " \
                         "render %d input %d failed: 0x%08x", i, j, status);
@@ -771,7 +1060,8 @@ static int setup_cp_render(const int i, const int j)
         }
 
         status = mmal_port_parameter_set_boolean(input,
-                                            MMAL_PARAMETER_ZERO_COPY, MMAL_TRUE);
+                                                 MMAL_PARAMETER_ZERO_COPY,
+                                                 MMAL_TRUE);
         if (status != MMAL_SUCCESS) {
             print_error("Setting zero-copy on " \
                         "isp %d input %d failed: 0x%08x", i, j, status);
@@ -781,7 +1071,8 @@ static int setup_cp_render(const int i, const int j)
     }
     status = mmal_component_enable(cp_renders[i][j]);
     if (status != MMAL_SUCCESS) {
-        print_error("Enabling render component %d,%d failed: 0x%08x", i, j, status);
+        print_error("Enabling render component %d,%d failed: 0x%08x",
+                    i, j, status);
         ret = 1;
         goto end;
     }
@@ -800,7 +1091,8 @@ static int connect_ports(const int i, const int len)
     if (cfg->use_camera_capture_port) {
         /* Connect camera preview port to null for AWB processing. */
         status = mmal_connection_create(&conn_camera_nulls[i],
-                                        cp_cameras[i]->output[CAMERA_PREVIEW_PORT],
+                                        cp_cameras[i]->
+                                                    output[CAMERA_PREVIEW_PORT],
                                         cp_nulls[i]->input[1],
                                         MMAL_CONNECTION_FLAG_TUNNELLING);
         if (status != MMAL_SUCCESS) {
@@ -811,24 +1103,35 @@ static int connect_ports(const int i, const int len)
         }
     }
 
-    status = mmal_connection_create(&conn_camera_splitters[i],
-                                    cp_cameras[i]->output[cfg->camera_output_port_index],
-                                    cp_splitters[i]->input[0],
-                                    MMAL_CONNECTION_FLAG_TUNNELLING);
-    if (status != MMAL_SUCCESS) {
-        print_error("Connecting " \
-                    "camera and splitter ports %d failed: 0x%08x", i, status);
-        ret = 1;
-        goto end;
-    }
-    for (j = 0; j < len; j ++) {
-        status = mmal_connection_create(&conn_splitters_isps[i][j],
-                                        cp_splitters[i]->output[j],
-                                        cp_isps[i][j]->input[0],
+    if (!cfg->is_rawcam) {
+        status = mmal_connection_create(&conn_camera_splitters[i],
+                                        cp_cameras[i]->
+                                          output[cfg->camera_output_port_index],
+                                        cp_splitters[i]->input[0],
                                         MMAL_CONNECTION_FLAG_TUNNELLING);
         if (status != MMAL_SUCCESS) {
             print_error("Connecting " \
-                        "splitter and isp ports %d,%d failed: 0x%08x", i, j, status);
+                        "camera and splitter ports %d failed: 0x%08x", i, status);
+            ret = 1;
+            goto end;
+        }
+    }
+
+    for (j = 0; j < len; j ++) {
+        if (!cfg->is_rawcam)
+            status = mmal_connection_create(&conn_splitters_isps[i][j],
+                                            cp_splitters[i]->output[j],
+                                            cp_isps[i][j]->input[0],
+                                            MMAL_CONNECTION_FLAG_TUNNELLING);
+        else
+            status = mmal_connection_create(&conn_splitters_isps[i][j],
+                                            cpw_splitters[i]->output[j],
+                                            cp_isps[i][j]->input[0],
+                                            MMAL_CONNECTION_FLAG_TUNNELLING);
+        if (status != MMAL_SUCCESS) {
+            print_error("Connecting "
+                        "splitter and isp ports %d,%d failed: 0x%08x",
+                        i, j, status);
             ret = 1;
             goto end;
         }
@@ -837,8 +1140,9 @@ static int connect_ports(const int i, const int len)
                                         cp_renders[i][j]->input[0],
                                         0);
         if (status != MMAL_SUCCESS) {
-            print_error("Connecting " \
-                        "isp and render ports %d,%d failed: 0x%08x", i, j, status);
+            print_error("Connecting "
+                        "isp and render ports %d,%d failed: 0x%08x",
+                        i, j, status);
             ret = 1;
             goto end;
         }
@@ -848,7 +1152,7 @@ static int connect_ports(const int i, const int len)
         conn_isps_renders[i][j]->callback = callback_conn;
         status = mmal_connection_enable(conn_isps_renders[i][j]);
         if (status != MMAL_SUCCESS) {
-            print_error("Enabling connection between " \
+            print_error("Enabling connection between "
                         "splitter and isp %d,%d failed: 0x%08x", i, j, status);
             ret = 1;
             goto end;
@@ -856,7 +1160,7 @@ static int connect_ports(const int i, const int len)
         conn_splitters_isps[i][j]->callback = callback_conn;
         status = mmal_connection_enable(conn_splitters_isps[i][j]);
         if (status != MMAL_SUCCESS) {
-            print_error("Enabling connection between " \
+            print_error("Enabling connection between "
                         "splitter and isp %d,%d failed: 0x%08x", i, j, status);
             ret = 1;
             goto end;
@@ -866,19 +1170,21 @@ static int connect_ports(const int i, const int len)
         conn_camera_nulls[i]->callback = callback_conn;
         status = mmal_connection_enable(conn_camera_nulls[i]);
         if (status != MMAL_SUCCESS) {
-            print_error("Enabling connection between " \
+            print_error("Enabling connection between "
                         "camera and null %d,%d failed: 0x%08x", i, j, status);
             ret = 1;
             goto end;
         }
     }
-    conn_camera_splitters[i]->callback = callback_conn;
-    status = mmal_connection_enable(conn_camera_splitters[i]);
-    if (status != MMAL_SUCCESS) {
-        print_error("Enabling connection between " \
-                    "camera and splitter %d,%d failed: 0x%08x", i, j, status);
-        ret = 1;
-        goto end;
+    if (!cfg->is_rawcam) {
+        conn_camera_splitters[i]->callback = callback_conn;
+        status = mmal_connection_enable(conn_camera_splitters[i]);
+        if (status != MMAL_SUCCESS) {
+            print_error("Enabling connection between "
+                        "camera and splitter %d,%d failed: 0x%08x", i, j, status);
+            ret = 1;
+            goto end;
+        }
     }
 
     for (j = 0; j < len; j ++) {
@@ -920,11 +1226,19 @@ int rpigrafx_finish_config()
             max_width  = MMAL_MAX(max_width,  isps_config[i][j].width);
             max_height = MMAL_MAX(max_height, isps_config[i][j].height);
         }
+        cfg->width = max_width;
+        cfg->height = max_height;
 
-        if ((ret = setup_cp_camera(i, max_width, max_height,
-                                   cfg->use_camera_capture_port)))
-            goto end;
-        if ((ret = setup_cp_splitter(i, len, max_width, max_height)))
+        if (cfg->is_rawcam) {
+            if ((ret = setup_cp_camera_rawcam(i, max_width, max_height)))
+                goto end;
+        } else {
+            if ((ret = setup_cp_camera(i, max_width, max_height,
+                                       cfg->use_camera_capture_port)))
+                goto end;
+        }
+        if ((ret = setup_cp_splitter(i, len, max_width, max_height,
+                                     cfg->is_rawcam)))
             goto end;
         if (cfg->use_camera_capture_port)
             if ((ret = setup_cp_null(i, max_width, max_height)))
@@ -949,13 +1263,18 @@ int rpigrafx_capture_next_frame(rpigrafx_frame_config_t *fcp)
     struct cameras_config *cfg = &cameras_config[fcp->camera_number];
     int ret = 0;
     MMAL_BUFFER_HEADER_T *header = NULL;
-    MMAL_CONNECTION_T *conn = conn_isps_renders[fcp->camera_number][fcp->splitter_output_port_index];
+    const int32_t width = cfg->width,
+                  height = cfg->height,
+                  /* Stride in header->data. */
+                  stride = ALIGN_UP(width, 32),
+                  raw_width = rpiraw_width_raw8_to_raw10_rpi(width);
+    MMAL_STATUS_T status;
 
     if (cfg->use_camera_capture_port) {
-        MMAL_STATUS_T status;
-
-        status = mmal_port_parameter_set_boolean(cp_cameras[fcp->camera_number]->output[cfg->camera_output_port_index],
-                                                 MMAL_PARAMETER_CAPTURE, MMAL_TRUE);
+        status = mmal_port_parameter_set_boolean(cp_cameras[fcp->camera_number]
+                                        ->output[cfg->camera_output_port_index],
+                                                 MMAL_PARAMETER_CAPTURE,
+                                                 MMAL_TRUE);
         if (status != MMAL_SUCCESS) {
             print_error("Setting capture to "
                         "camera %d output %d failed: 0x%08x\n",
@@ -972,25 +1291,150 @@ int rpigrafx_capture_next_frame(rpigrafx_frame_config_t *fcp)
         return ret;
     }
 
-retry:
+    if (cfg->is_rawcam) {
+        for (; ; ) {
+            MMAL_PORT_T *output = cpw_rawcams[fcp->camera_number]->output[0],
+                        *input = cpw_splitters[fcp->camera_number]->input[0];
+            MMAL_QUEUE_T *input_queue = cpw_splitters[fcp->camera_number]->
+                                                           input_pool[0]->queue;
+            uint8_t *raw8 = NULL;
 
-    while ((header = mmal_queue_get(conn->pool->queue)) != NULL) {
-        if (priv_rpigrafx_verbose)
-            WARN_HEADER("Got header ", header, " from conn->pool->queue; " \
-                                               "Sending to conn->out");
-        mmal_port_send_buffer(conn->out, header);
+            for (; ; ) {
+                _Bool exit_loop = 0;
+                status = mmal_wrapper_buffer_get_empty(output, &header, 0);
+                switch (status) {
+                    case MMAL_SUCCESS:
+                        status = mmal_port_send_buffer(output, header);
+                        if (status != MMAL_SUCCESS) {
+                            print_error("Failed to send empty buffer to rawcam:"
+                                        " 0x%08x", status);
+                            ret = 1;
+                            goto end;
+                        }
+                        break;
+                    case MMAL_EAGAIN:
+                        exit_loop = !0;
+                        break;
+                    default:
+                        print_error("Failed to get empty header: 0x%08x",
+                                    status);
+                        ret = 1;
+                        goto end;
+                }
+                if (exit_loop)
+                    break;
+            }
+
+            status = mmal_wrapper_buffer_get_full(output, &header,
+                                                  MMAL_WRAPPER_FLAG_WAIT);
+            if (status != MMAL_SUCCESS) {
+                print_error("Failed to get full header from rawcam: 0x%08x",
+                            status);
+                ret = 1;
+                goto end;
+            }
+
+            /* Raw info etc... */
+            if (header->flags & MMAL_BUFFER_HEADER_FLAG_CODECSIDEINFO) {
+                mmal_buffer_header_release(header);
+                continue;
+            }
+
+            raw8 = malloc(width * height);
+            if (raw8 == NULL) {
+                print_error("Failed to allocate raw8: %s", strerror(errno));
+                ret = 1;
+                goto end;
+            }
+
+            print_error("length = %d, alloc = %d, flags = 0x%08x", header->length, header->alloc_size, header->flags);
+            /* xxx: Add stride argument to this call. */
+            ret = rpiraw_convert_raw10_to_raw8(raw8, header->data,
+                                               width, height, raw_width);
+            if (ret) {
+                print_error("rpiraw_convert_raw10_to_raw8: %d", ret);
+                goto end;
+            }
+
+            mmal_buffer_header_release(header);
+
+            header = mmal_queue_wait(input_queue);
+            if (header == NULL) {
+                print_error("Failed to wait for header from rawcam");
+                ret = 1;
+                goto end;
+            }
+            ret = rpiraw_raw8bggr_to_rgb888_nearest_neighbor(header->data,
+                                                             stride,
+                                                             raw8,
+                                                             width, width,
+                                                             height);
+            if (ret) {
+                print_error("rpiraw_raw8bggr_to_rgb888_nearest_neighbor: %d",
+                            ret);
+                goto end;
+            }
+
+            free(raw8);
+
+            {
+                uint32_t hist_r[256], hist_g[256], hist_b[256], sum = 0;
+                ret = rpiraw_calc_histogram_rgb888(hist_r, hist_g, hist_b,
+                                                   header->data,
+                                                   stride, width, height);
+                sum = hist_r[255] + hist_g[255] + hist_b[255];
+                ret = rpicam_imx219_tuner(RPICAM_IMX219_TUNER_METHOD_HEURISTIC,
+                                          &cfg->rpicam_config.imx219, sum);
+            }
+
+            /*
+             * Wait! The header here is not the one the user requested. We pass
+             * it to the splitter and wait for the isp to crop them.
+             */
+
+            for (int k = 0; k < 10; k ++)
+                ((uint8_t*)header->data)[k] = 0xff;
+            /* xxx: stride * height * 3 ? */
+            header->length = width * height * 3;
+            header->flags = MMAL_BUFFER_HEADER_FLAG_EOS;
+            status = mmal_port_send_buffer(input, header);
+            if (status != MMAL_SUCCESS) {
+                print_error("Failed to send buffer to splitter: 0x%08x",
+                            status);
+                ret = 1;
+                goto end;
+            }
+
+            break;
+        }
     }
 
-    header = mmal_queue_wait(conn->queue);
-    if (priv_rpigrafx_verbose)
-        WARN_HEADER("Got header ", header, " from conn->queue");
-    /*
-     * camera[2] returns empty queue once every two headers.
-     * Retry until we get the full header.
-     */
-    if (header->length == 0) {
-        mmal_buffer_header_release(header);
-        goto retry;
+    for (; ; ) {
+        MMAL_CONNECTION_T *conn = conn_isps_renders[fcp->camera_number]
+                                              [fcp->splitter_output_port_index];
+
+        while ((header = mmal_queue_get(conn->pool->queue)) != NULL) {
+            if (priv_rpigrafx_verbose)
+                WARN_HEADER("Got header ", header,
+                            " from conn->pool->queue; "
+                            "Sending to conn->out");
+            mmal_port_send_buffer(conn->out, header);
+        }
+
+        header = mmal_queue_wait(conn->queue);
+        if (priv_rpigrafx_verbose)
+            WARN_HEADER("Got header ", header, " from conn->queue");
+        /*
+         * camera[2] returns empty queue once every two headers.
+         * Retry until we get the full header.
+         * It's safe to do this for preview port or rawcam.
+         */
+        /* xxx: Not to do this here? */
+        if (header->length == 0) {
+            mmal_buffer_header_release(header);
+            continue;
+        }
+        break;
     }
 
     ctx->header = header;
@@ -1028,11 +1472,13 @@ int rpigrafx_free_frame(rpigrafx_frame_config_t *fcp)
     struct callback_context *ctx = fcp->ctx;
     int ret = 0;
 
-    if (ctx->header != NULL && !ctx->is_header_passed_to_render) {
-        if (priv_rpigrafx_verbose)
-            WARN_HEADER("Releasing header ", ctx->header, "");
-        mmal_buffer_header_release(ctx->header);
-    }
+    if (ctx->header == NULL || ctx->is_header_passed_to_render)
+        return 0;
+
+    if (priv_rpigrafx_verbose)
+        WARN_HEADER("Releasing header ", ctx->header, "");
+    mmal_buffer_header_release(ctx->header);
+
     ctx->header = NULL;
     ctx->is_header_passed_to_render = 0;
 
@@ -1053,7 +1499,9 @@ int rpigrafx_render_frame(rpigrafx_frame_config_t *fcp)
         goto end;
     }
 
-    status = mmal_port_send_buffer(conn_isps_renders[fcp->camera_number][fcp->splitter_output_port_index]->in, fcp->ctx->header);
+    status = mmal_port_send_buffer(conn_isps_renders[fcp->camera_number]
+                                          [fcp->splitter_output_port_index]->in,
+                                   fcp->ctx->header);
     if (status != MMAL_SUCCESS) {
         print_error("Sending header to render failed: 0x%08x", status);
         goto end;

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,9 +1,12 @@
-AM_CFLAGS = -pipe -O2 -g -W -Wall -Wextra -I$(top_srcdir)/include $(BCM_HOST_CFLAGS) $(MMAL_CFLAGS)
+AM_CFLAGS = -pipe -O2 -g -W -Wall -Wextra -I$(top_srcdir)/include $(BCM_HOST_CFLAGS) $(MMAL_CFLAGS) $(RPICAM_CFLAGS) $(RPIRAW_CFLAGS)
 
-check_PROGRAMS = test_dispmanx test_capture_render_seq
+check_PROGRAMS = test_dispmanx test_capture_render_seq test_rawcam_imx219
 
 nodist_test_dispmanx_SOURCES = test_dispmanx.c
-test_dispmanx_LDADD = $(top_builddir)/src/.libs/librpigrafx.a $(BCM_HOST_LIBS) $(MMAL_LIBS)
+test_dispmanx_LDADD = $(top_builddir)/src/.libs/librpigrafx.a $(BCM_HOST_LIBS) $(MMAL_LIBS) $(RPICAM_LIBS) $(RPIRAW_LIBS)
 
 nodist_test_capture_render_seq_SOURCES = test_capture_render_seq.c
-test_capture_render_seq_LDADD = $(top_builddir)/src/.libs/librpigrafx.a $(BCM_HOST_LIBS) $(MMAL_LIBS) $(QMKL_LIBS)
+test_capture_render_seq_LDADD = $(top_builddir)/src/.libs/librpigrafx.a $(BCM_HOST_LIBS) $(MMAL_LIBS) $(QMKL_LIBS) $(RPICAM_LIBS) $(RPIRAW_LIBS)
+
+nodist_test_rawcam_imx219_SOURCES = test_rawcam_imx219.c
+test_rawcam_imx219_LDADD = $(top_builddir)/src/.libs/librpigrafx.a $(BCM_HOST_LIBS) $(MMAL_LIBS) $(RPICAM_LIBS) $(RPIRAW_LIBS)

--- a/test/test_rawcam_imx219.c
+++ b/test/test_rawcam_imx219.c
@@ -13,9 +13,11 @@
 int main()
 {
     int i;
+    int screen_width, screen_height;
     rpigrafx_frame_config_t fc;
 
     rpigrafx_set_verbose(1);
+    _check(rpigrafx_get_screen_size(&screen_width, &screen_height));
     _check(rpigrafx_config_camera_frame(0, 2048, 2048,
                                         MMAL_ENCODING_RGB24, 0, &fc));
     _check(rpigrafx_config_rawcam(RPIGRAFX_RAWCAM_CAMERA_MODEL_IMX219,
@@ -27,7 +29,7 @@ int main()
     _check(rpigrafx_config_rawcam_imx219(24.0, 0, 0, 1, 1,
                                        RPIGRAFX_RAWCAM_IMX219_BINNING_MODE_NONE,
                                          &fc));
-    _check(rpigrafx_config_camera_frame_render(0, 0, 0, 2048, 2048, 0, &fc));
+    _check(rpigrafx_config_camera_frame_render(0, 0, 0, screen_width, screen_height, 0, &fc));
     _check(rpigrafx_finish_config());
 
     for (i = 0; i < 100; i ++) {

--- a/test/test_rawcam_imx219.c
+++ b/test/test_rawcam_imx219.c
@@ -1,0 +1,42 @@
+#include <rpigrafx.h>
+#include <stdio.h>
+
+#define _check(x) \
+    do { \
+        const int ret = ((x)); \
+        if (ret) { \
+            fprintf(stderr, "%s:%d: error: %d\n", __FILE__, __LINE__, ret); \
+            exit(EXIT_FAILURE); \
+        } \
+    } while (0)
+
+int main()
+{
+    int i;
+    rpigrafx_frame_config_t fc;
+
+    rpigrafx_set_verbose(1);
+    _check(rpigrafx_config_camera_frame(0, 2048, 2048,
+                                        MMAL_ENCODING_RGB24, 0, &fc));
+    _check(rpigrafx_config_rawcam(RPIGRAFX_RAWCAM_CAMERA_MODEL_IMX219,
+                                  MMAL_CAMERA_RX_CONFIG_DECODE_NONE,
+                                  MMAL_CAMERA_RX_CONFIG_ENCODE_NONE,
+                                  MMAL_CAMERA_RX_CONFIG_UNPACK_NONE,
+                                  MMAL_CAMERA_RX_CONFIG_PACK_NONE,
+                                  2, 10, &fc));
+    _check(rpigrafx_config_rawcam_imx219(24.0, 0, 0, 1, 1,
+                                       RPIGRAFX_RAWCAM_IMX219_BINNING_MODE_NONE,
+                                         &fc));
+    _check(rpigrafx_config_camera_frame_render(0, 0, 0, 2048, 2048, 0, &fc));
+    _check(rpigrafx_finish_config());
+
+    for (i = 0; i < 100; i ++) {
+        void *p = NULL;
+        fprintf(stderr, "#%d\n", i);
+        _check(rpigrafx_capture_next_frame(&fc));
+        p = rpigrafx_get_frame(&fc);
+        _check(rpigrafx_render_frame(&fc));
+    }
+
+    return 0;
+}

--- a/test/test_rawcam_imx219.c
+++ b/test/test_rawcam_imx219.c
@@ -25,7 +25,7 @@ int main()
                                   MMAL_CAMERA_RX_CONFIG_ENCODE_NONE,
                                   MMAL_CAMERA_RX_CONFIG_UNPACK_NONE,
                                   MMAL_CAMERA_RX_CONFIG_PACK_NONE,
-                                  2, 10, &fc));
+                                  2, 10, RPIGRAFX_BAYER_PATTERN_BGGR, &fc));
     _check(rpigrafx_config_rawcam_imx219(24.0, 0, 0, 1, 1,
                                        RPIGRAFX_RAWCAM_IMX219_BINNING_MODE_NONE,
                                          &fc));


### PR DESCRIPTION
`rawcam` is a framework provided by the Raspberry Pi firmware that enables to receive raw image from MIPI/CSI-2 image sensor directly. By using this you can use any cameras the firmware doesn't support for.

This time we support for IMX219 on rawcam. Camera controlling through I2C is done by [librpicam](https://github.com/Idein/librpicam) (which is private for now because it involves register settings under NDA ([there is a """public""" datasheet](https://github.com/rellimmot/Sony-IMX219-Raspberry-Pi-V2-CMOS/blob/master/IMX219PQH5_Module_Design_Reference_Manual_ver2.2_140425.pdf) however)) and raw demosaicing is done by [librpiraw](https://github.com/Idein/librpiraw).

Though the image quality is so bad for now because we aren't applying noise reduction etc., but we can now use IMX219 without ATSHA204A. How to:

```
$ git clone https://github.com/Terminus-IMRC/librpigrafx2
$ cd librpigrafx2/
$ autoreconf -i -m
$ ./configure
$ make check
$ wget https://raw.githubusercontent.com/6by9/userland/rawcam/camera_i2c
$ chmod u+x camera_i2c
$ ./camera_i2c
$ ./test/test_rawcam_imx219
```